### PR TITLE
ITKDev: Fixes must not be accessed before initialization

### DIFF
--- a/src/LookupResult/CompanyLookupResult.php
+++ b/src/LookupResult/CompanyLookupResult.php
@@ -352,7 +352,7 @@ class CompanyLookupResult {
    *   The field value or the empty string if the field does not exist.
    */
   public function getFieldValue(string $field): mixed {
-    if (property_exists($this, $field)) {
+    if (property_exists($this, $field) && isset($this->{$field})) {
       return $this->{$field};
     }
 

--- a/src/LookupResult/CprLookupResult.php
+++ b/src/LookupResult/CprLookupResult.php
@@ -672,7 +672,7 @@ class CprLookupResult {
    *   The value of the field or the empty string.
    */
   public function getFieldValue(string $field): mixed {
-    if (property_exists($this, $field)) {
+    if (property_exists($this, $field) && isset($this->{$field})) {
       return $this->{$field};
     }
 


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/?tab=timesheet#/tickets/showTicket/3103

#### Description

Error: Typed property Drupal\os2web_datalookup\LookupResult\CprLookupResult::$name must not be accessed before initialization in Drupal\os2web_datalookup\LookupResult\CprLookupResult->getFieldValue() (line 676 of /app/web/modules/contrib/os2web_datalookup/src/LookupResult/CprLookupResult.php)

This results in a 500 back to the user or service in PHP >= 8.3 (PHP message: **Uncaught PHP Exception**).

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change
should be exempt from the list.

#### Additional comments or questions

N/A
