### PR TITLE
Add missing import statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Added missing use statement to fix issue on datafordeler settings pages
+  `pnumber_lookup`, `cvr_lookup` and `cpr_lookup`.
+
 ## [2.0.3] 2025-01-24
 
 * Fixing warning if foedselsdato not set.

--- a/src/Routing/DataLookupRoutes.php
+++ b/src/Routing/DataLookupRoutes.php
@@ -5,6 +5,7 @@ namespace Drupal\os2web_datalookup\Routing;
 use Drupal\Component\Plugin\PluginManagerInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\os2web_datalookup\Form\DataLookupPluginGroupSettingsForm;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\Route;
 


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/3691

#### Description

* Adds missing import statement to fix issue on datafordeler settings pages "pnumber_lookup", "cvr_lookup" and "cpr_lookup" .

_InvalidArgumentException: Class "Drupal\os2web_datalookup\Routing\DataLookupPluginGroupSettingsForm" does not exist. in Drupal\Core\DependencyInjection\ClassResolver->getInstanceFromDefinition() (line 37 of core/lib/Drupal/Core/DependencyInjection/ClassResolver.php)._