### PR TITLE
Avoid CVR city containing postal code if city is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Ensure postal code is only added to city if `CVRAdresse_postdistrikt` is not set.
 * Added missing use statement to fix issue on datafordeler settings pages
   `pnumber_lookup`, `cvr_lookup` and `cpr_lookup`.
 

--- a/src/Plugin/os2web/DataLookup/DatafordelerCVR.php
+++ b/src/Plugin/os2web/DataLookup/DatafordelerCVR.php
@@ -95,7 +95,7 @@ class DatafordelerCVR extends DatafordelerBase implements DataLookupCompanyInter
         $cvrResult->setApartmentNr($address->CVRAdresse_doerbetegnelse ?? '');
         $cvrResult->setPostalCode($address->CVRAdresse_postnummer ?? '');
         $city = $address->CVRAdresse_postdistrikt ?? $cvrResult->getPostalCode();
-	$cvrResult->setCity($city);
+        $cvrResult->setCity($city);
         $cvrResult->setMunicipalityCode($address->CVRAdresse_kommunekode ?? '');
 
         // Composing full address in one line.

--- a/src/Plugin/os2web/DataLookup/DatafordelerCVR.php
+++ b/src/Plugin/os2web/DataLookup/DatafordelerCVR.php
@@ -94,11 +94,8 @@ class DatafordelerCVR extends DatafordelerBase implements DataLookupCompanyInter
         $cvrResult->setFloor($address->CVRAdresse_etagebetegnelse ?? '');
         $cvrResult->setApartmentNr($address->CVRAdresse_doerbetegnelse ?? '');
         $cvrResult->setPostalCode($address->CVRAdresse_postnummer ?? '');
-        $city = implode(' ', array_filter([
-          $address->CVRAdresse_postdistrikt ?? NULL,
-          $cvrResult->getPostalCode() ?? NULL,
-        ]));
-        $cvrResult->setCity($city);
+        $city = $address->CVRAdresse_postdistrikt ?? $cvrResult->getPostalCode();
+	$cvrResult->setCity($city);
         $cvrResult->setMunicipalityCode($address->CVRAdresse_kommunekode ?? '');
 
         // Composing full address in one line.


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/3690

#### Description

* CVR lookup: Ensure postal code is only added to city if `CVRAdresse_postdistrikt` is not set.