### PR TITLE
Release 2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.4] 2025-01-29
+
 * Ensure postal code is only added to city if `CVRAdresse_postdistrikt` is not set.
 * Added missing use statement to fix issue on datafordeler settings pages
   `pnumber_lookup`, `cvr_lookup` and `cpr_lookup`.
@@ -27,7 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Audit logging.
 
-[Unreleased]: https://github.com/os2web/os2web_datalookup/compare/2.0.3...HEAD
+[Unreleased]: https://github.com/os2web/os2web_datalookup/compare/2.0.4...HEAD
+[2.0.4]: https://github.com/os2web/os2web_datalookup/compare/2.0.3...2.0.4
 [2.0.3]: https://github.com/os2web/os2web_datalookup/compare/2.0.2...2.0.3
 [2.0.2]: https://github.com/os2web/os2web_datalookup/compare/2.0.1...2.0.2
 [2.0.1]: https://github.com/os2web/os2web_datalookup/compare/2.0.0...2.0.1


### PR DESCRIPTION
Prepares release 2.0.4

* Ensure postal code is only added to city if `CVRAdresse_postdistrikt` is not set.
* Added missing use statement to fix issue on datafordeler settings pages
  `pnumber_lookup`, `cvr_lookup` and `cpr_lookup`.