### PR TITLE
Set actual identifier from lookup on lookup result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-22](https://github.com/OS2web/os2web_datalookup/pull/22)
+  Set actual identifier from lookup on lookup result
+
 ## [2.0.4] 2025-01-29
 
 * Ensure postal code is only added to city if `CVRAdresse_postdistrikt` is not set.

--- a/src/Plugin/os2web/DataLookup/DatafordelerCVR.php
+++ b/src/Plugin/os2web/DataLookup/DatafordelerCVR.php
@@ -80,7 +80,7 @@ class DatafordelerCVR extends DatafordelerBase implements DataLookupCompanyInter
     $cvrResult = new CompanyLookupResult();
     if ($result && isset($result->virksomhed) && !empty((array) $result->virksomhed)) {
       $cvrResult->setSuccessful();
-      $cvrResult->setCvr($param);
+      $cvrResult->setCvr($result->virksomhed->CVRNummer);
 
       if ($result->virksomhedsnavn) {
         $cvrResult->setName($result->virksomhedsnavn->vaerdi);

--- a/src/Plugin/os2web/DataLookup/ServiceplatformenCPR.php
+++ b/src/Plugin/os2web/DataLookup/ServiceplatformenCPR.php
@@ -164,6 +164,7 @@ class ServiceplatformenCPR extends ServiceplatformenBase implements DataLookupCp
     // If all goes well, we return an address array.
     if ($result['status']) {
       $cprResult->setSuccessful();
+      // @todo Use a value from from $result to set CPR. But which key?
       $cprResult->setCpr($cpr);
       $cprResult->setName($result['adresseringsnavn'] ?? '');
       $cprResult->setStreet($result['vejadresseringsnavn'] ?? '');

--- a/src/Plugin/os2web/DataLookup/ServiceplatformenCPRExtended.php
+++ b/src/Plugin/os2web/DataLookup/ServiceplatformenCPRExtended.php
@@ -125,9 +125,9 @@ class ServiceplatformenCPRExtended extends ServiceplatformenBase implements Data
     // If all goes well, we return an address array.
     if ($result['status']) {
       $cprResult->setSuccessful();
-      $cprResult->setCpr($cpr);
 
       $persondata = $result['persondata'];
+      $cprResult->setCpr($persondata->personnummer);
 
       if ($persondata->status) {
         if ($persondata->status->status == self::CPR_STATUS_DEAD) {

--- a/src/Plugin/os2web/DataLookup/ServiceplatformenCVR.php
+++ b/src/Plugin/os2web/DataLookup/ServiceplatformenCVR.php
@@ -120,7 +120,7 @@ class ServiceplatformenCVR extends ServiceplatformenBase implements DataLookupCo
     $cvrResult = new CompanyLookupResult();
     if ($result['status']) {
       $cvrResult->setSuccessful();
-      $cvrResult->setCvr($param);
+      $cvrResult->setCvr($result['cvr']);
 
       $cvrResult->setName($result['company_name']);
       $cvrResult->setStreet($result['company_street']);


### PR DESCRIPTION
#### Description

Handles https://github.com/OS2web/os2web_datalookup/issues/23

When performing a CPR lookup, the lookup can be succesful even when the CPR contains non-numeric characters, e.g. looking up `261174-0000` will return the same result as when looking up `“2611740000` (or `261174💩0000`). (The CPR lookup service complains if a non-numeric CPR is provided.)

However, the returned lookup result does not contain the actual identifier (CPR or CVR), but the identifier used to perform the lookup. This can lead to issues when using the lookup result to send digital post or call other services expecting a clean CPR/CPR, i.e. an identifier containing only decimal digits.

This code in this pull request sets the identifier from the actual lookup on the result, in effect sanitizing the identifier on the result.

The service used by `src/Plugin/os2web/DataLookup/ServiceplatformenCPR.php` is deprecated so no changes are made there (apart from adding a `@TODO` annotation).

#### Checklist

- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

> [!IMPORTANT]
> The failing actions are not related to changes in this pull request and must be addressed in a separate pull request.