### PR TITLE
OS-245 updating CRV datafordeler endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Datafordeler CRV service endpoint update - GraphQL. 
 
 ## [3.0.3] - 2025-11-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-* Datafordeler CRV service endpoint update - GraphQL. 
+* Datafordeler CVR service endpoint update - GraphQL. 
 
 ## [3.0.3] - 2025-11-19
 

--- a/src/Plugin/os2web/DataLookup/DatafordelerCVR.php
+++ b/src/Plugin/os2web/DataLookup/DatafordelerCVR.php
@@ -90,12 +90,16 @@ class DatafordelerCVR extends DataLookupBase implements DataLookupCompanyInterfa
    */
   public function lookup(string $param): CompanyLookupResult {
     try {
+      if (!preg_match('/^\d{8}$/', $param)) {
+        throw new \InvalidArgumentException('CVR must be exactly 8 digits.');
+      }
+
       $msg = sprintf('Hent virksomhed med CVRNummer: %s', $param);
       $this->auditLogger->info('DataLookup', $msg);
       $response = $this->executeQuery($param);
       $result = json_decode((string) $response->getBody());
     }
-    catch (GuzzleException $e) {
+    catch (GuzzleException | \InvalidArgumentException $e) {
       $msg = sprintf('Hent virksomhed med CVRNummer (%s): %s', $param, $e->getMessage());
       $this->auditLogger->error('DataLookup', $msg);
       $result = $e->getMessage();

--- a/src/Plugin/os2web/DataLookup/DatafordelerCVR.php
+++ b/src/Plugin/os2web/DataLookup/DatafordelerCVR.php
@@ -169,8 +169,13 @@ class DatafordelerCVR extends DataLookupBase implements DataLookupCompanyInterfa
   private function executeQuery($cvr): ResponseInterface {
     $this->httpClient = new Client();
 
+    // Setting date to TODAY 00:00:00, so that we are always getting up-to-date
+    // information.
+    $virkningstid = (new \DateTimeImmutable('today', new \DateTimeZone('UTC')))
+      ->format('Y-m-d\T00:00:00\Z');
+
     $query = <<<GRAPHQL
-{ CVR_Virksomhed(first: 1, virkningstid: "2024-01-01T00:00:00Z", where: { CVRNummer: { eq: {$cvr} } }) {
+{ CVR_Virksomhed(first: 1, virkningstid: "{$virkningstid}", where: { CVRNummer: { eq: {$cvr} } }) {
     nodes {
       CVRNummer
       id_CVR_CVREnhed_id_ref(first: 1) {

--- a/src/Plugin/os2web/DataLookup/DatafordelerCVR.php
+++ b/src/Plugin/os2web/DataLookup/DatafordelerCVR.php
@@ -163,7 +163,8 @@ class DatafordelerCVR extends DataLookupBase implements DataLookupCompanyInterfa
    *
    * @return \Psr\Http\Message\ResponseInterface
    *   The raw HTTP response from the GraphQL endpoint.
-   * @throws GuzzleException
+   *
+   * @throws \GuzzleHttp\Exception\GuzzleException
    */
   private function executeQuery($cvr): ResponseInterface {
     $this->httpClient = new Client();
@@ -175,7 +176,7 @@ class DatafordelerCVR extends DataLookupBase implements DataLookupCompanyInterfa
       id_CVR_CVREnhed_id_ref(first: 1) {
         nodes {
           id_CVR_Navn_CVREnhedsId_ref { vaerdi }
-          id_CVR_Adressering_CVREnhedsId_ref(first: 2, where: { AdresseringAnvendelse: { in: ["beliggenhedsadresse", "postadresse"] } }) {
+          id_CVR_Adressering_CVREnhedsId_ref(first: 1, where: { AdresseringAnvendelse: { in: ["beliggenhedsadresse", "postadresse"] } }) {
             nodes {
               AdresseringAnvendelse
               CVRAdresse_vejnavn

--- a/src/Plugin/os2web/DataLookup/DatafordelerCVR.php
+++ b/src/Plugin/os2web/DataLookup/DatafordelerCVR.php
@@ -6,7 +6,9 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\os2web_datalookup\LookupResult\CompanyLookupResult;
-use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Defines a plugin for DatafordelerCVR.
@@ -17,14 +19,22 @@ use GuzzleHttp\Exception\ClientException;
  *   group = "cvr_lookup"
  * )
  */
-class DatafordelerCVR extends DatafordelerBase implements DataLookupCompanyInterface {
+class DatafordelerCVR extends DataLookupBase implements DataLookupCompanyInterface {
+
+  /**
+   * Http client.
+   *
+   * @var \GuzzleHttp\Client
+   */
+  protected Client $httpClient;
 
   /**
    * {@inheritdoc}
    */
   public function defaultConfiguration(): array {
     return [
-      'webserviceurl_live' => 'https://s5-certservices.datafordeler.dk/CVR/HentCVRData/1/REST/',
+      'webserviceurl_live' => 'https://graphql.datafordeler.dk/flexibleCurrent/v1',
+      'api_key' => '',
     ] + parent::defaultConfiguration();
   }
 
@@ -32,7 +42,18 @@ class DatafordelerCVR extends DatafordelerBase implements DataLookupCompanyInter
    * {@inheritdoc}
    */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
-    $form = parent::buildConfigurationForm($form, $form_state);
+    $form['webserviceurl_live'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Webservice URL (LIVE)'),
+      '#description' => $this->t('Live URL against which to make the request, e.g. https://graphql.datafordeler.dk/flexibleCurrent/v1'),
+      '#default_value' => $this->configuration['webserviceurl_live'],
+    ];
+
+    $form['api_key'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('API Key'),
+      '#default_value' => $this->configuration['api_key'],
+    ];
 
     $form['test_cvr'] = [
       '#type' => 'textfield',
@@ -46,7 +67,12 @@ class DatafordelerCVR extends DatafordelerBase implements DataLookupCompanyInter
    * {@inheritdoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state): void {
-    parent::submitConfigurationForm($form, $form_state);
+    $keys = array_keys($this->defaultConfiguration());
+    $configuration = $this->getConfiguration();
+    foreach ($keys as $key) {
+      $configuration[$key] = $form_state->getValue($key);
+    }
+    $this->setConfiguration($configuration);
 
     if (!empty($form_state->getValue('test_cvr'))) {
       $lookupResult = $this->lookup($form_state->getValue('test_cvr'));
@@ -66,26 +92,28 @@ class DatafordelerCVR extends DatafordelerBase implements DataLookupCompanyInter
     try {
       $msg = sprintf('Hent virksomhed med CVRNummer: %s', $param);
       $this->auditLogger->info('DataLookup', $msg);
-      $response = $this->getResponse('hentVirksomhedMedCVRNummer', ['query' => ['pCVRNummer' => $param]]);
+      $response = $this->executeQuery($param);
       $result = json_decode((string) $response->getBody());
     }
-    catch (ClientException $e) {
+    catch (GuzzleException $e) {
       $msg = sprintf('Hent virksomhed med CVRNummer (%s): %s', $param, $e->getMessage());
       $this->auditLogger->error('DataLookup', $msg);
       $result = $e->getMessage();
     }
 
     $cvrResult = new CompanyLookupResult();
-    if ($result && isset($result->virksomhed) && !empty((array) $result->virksomhed)) {
+    if ($result && isset($result->data->CVR_Virksomhed->nodes) && !empty($result->data->CVR_Virksomhed->nodes)) {
+      $companyGraph = $result->data->CVR_Virksomhed->nodes[0]->id_CVR_CVREnhed_id_ref->nodes[0];
+
       $cvrResult->setSuccessful();
       $cvrResult->setCvr($param);
 
-      if ($result->virksomhedsnavn) {
-        $cvrResult->setName($result->virksomhedsnavn->vaerdi);
+      if ($companyGraph->id_CVR_Navn_CVREnhedsId_ref) {
+        $cvrResult->setName($companyGraph->id_CVR_Navn_CVREnhedsId_ref->vaerdi);
       }
 
-      if ($result->beliggenhedsadresse) {
-        $address = $result->beliggenhedsadresse;
+      if ($companyGraph->id_CVR_Adressering_CVREnhedsId_ref) {
+        $address = $companyGraph->id_CVR_Adressering_CVREnhedsId_ref->nodes[0];
 
         $cvrResult->setStreet($address->CVRAdresse_vejnavn ?? '');
         $cvrResult->setHouseNr($address->CVRAdresse_husnummerFra ?? '');
@@ -122,6 +150,60 @@ class DatafordelerCVR extends DatafordelerBase implements DataLookupCompanyInter
     }
 
     return $cvrResult;
+  }
+
+  /**
+   * Executes the GraphQL lookup request for a specific CVR number.
+   *
+   * Builds the GraphQL payload and sends it to the configured Datafordeler
+   * endpoint using the shared HTTP request flow from the parent class.
+   *
+   * @param string $cvr
+   *   The CVR number to look up.
+   *
+   * @return \Psr\Http\Message\ResponseInterface
+   *   The raw HTTP response from the GraphQL endpoint.
+   * @throws GuzzleException
+   */
+  private function executeQuery($cvr): ResponseInterface {
+    $this->httpClient = new Client();
+
+    $query = <<<GRAPHQL
+{ CVR_Virksomhed(first: 1, virkningstid: "2024-01-01T00:00:00Z", where: { CVRNummer: { eq: {$cvr} } }) {
+    nodes {
+      CVRNummer
+      id_CVR_CVREnhed_id_ref(first: 1) {
+        nodes {
+          id_CVR_Navn_CVREnhedsId_ref { vaerdi }
+          id_CVR_Adressering_CVREnhedsId_ref(first: 2, where: { AdresseringAnvendelse: { in: ["beliggenhedsadresse", "postadresse"] } }) {
+            nodes {
+              AdresseringAnvendelse
+              CVRAdresse_vejnavn
+              CVRAdresse_husnummerFra
+              CVRAdresse_etagebetegnelse
+              CVRAdresse_doerbetegnelse
+              CVRAdresse_postnummer
+              CVRAdresse_postdistrikt
+              CVRAdresse_kommunekode
+            }
+          }
+        }
+      }
+    }
+  }
+}
+GRAPHQL;
+
+    $webserviceUrl = $this->configuration['webserviceurl_live'];
+
+    return $this->httpClient->post($webserviceUrl, [
+      'query' => [
+        'apiKey' => $this->configuration['api_key'],
+      ],
+      'json' => [
+        'query' => $query,
+      ],
+    ]);
   }
 
 }


### PR DESCRIPTION
#### Link to ticket

https://github.com/OS2Forms/os2forms/issues/248

#### Description

Replacing the existing Datafordeler endpoint with a new endpoint based on GraphQL.

#### Additional comments or questions

This is a new of a kind Datafordeler webservice integration that is based on API key, and not the certificate as it used to.

That is why the architecture is changed a bit. Bear in mind, I deliberately decided not do put anything if the parent class and wait until have more example of the new Datafordeler webservices. After that the pattern will be more prominent, which will allow us to move the repetitive/shared features into the parent class
