### PR TITLE
Fetch first, middle and last name during CPR lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-30](https://github.com/OS2web/os2web_datalookup/pull/30)
+  Fetch first, middle and last name in CPR Lookup.
+
 ## [3.1.0] - 2026-04-27
 
 * [PR-29](https://github.com/OS2web/os2web_datalookup/pull/29)
-  Datafordeler CVR service endpoint update - GraphQL. 
+  Datafordeler CVR service endpoint update - GraphQL.
 
 ## [3.0.3] - 2025-11-19
 
@@ -55,7 +58,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Audit logging.
 
-[Unreleased]: https://github.com/os2web/os2web_datalookup/compare/3.0.0...HEAD
+[Unreleased]: https://github.com/os2web/os2web_datalookup/compare/3.1.0...HEAD
+[3.1.0]: https://github.com/os2web/os2web_datalookup/compare/3.0.3...3.1.0
+[3.0.3]: https://github.com/os2web/os2web_datalookup/compare/3.0.2...3.0.3
+[3.0.2]: https://github.com/os2web/os2web_datalookup/compare/3.0.1...3.0.2
+[3.0.1]: https://github.com/os2web/os2web_datalookup/compare/3.0.0...3.0.1
 [3.0.0]: https://github.com/os2web/os2web_datalookup/compare/2.0.4...3.0.0
 [2.0.4]: https://github.com/os2web/os2web_datalookup/compare/2.0.3...2.0.4
 [2.0.3]: https://github.com/os2web/os2web_datalookup/compare/2.0.2...2.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* [PR-30](https://github.com/OS2web/os2web_datalookup/pull/30)
+* [PR-31](https://github.com/OS2web/os2web_datalookup/pull/30)
   Fetch first, middle and last name in CPR Lookup.
 
 ## [3.1.0] - 2026-04-27

--- a/src/LookupResult/CprLookupResult.php
+++ b/src/LookupResult/CprLookupResult.php
@@ -9,6 +9,9 @@ class CprLookupResult {
 
   const CPR = 'cpr';
   const NAME = 'name';
+  const FIRST_NAME = 'firstName';
+  const MIDDLE_NAME = 'middleName';
+  const LAST_NAME = 'lastName';
   const STREET = 'street';
   const HOUSE_NR = 'houseNr';
   const FLOOR = 'floor';
@@ -46,6 +49,27 @@ class CprLookupResult {
    * @var string
    */
   protected string $name;
+
+  /**
+   * First name of the person.
+   *
+   * @var string
+   */
+  protected string $firstName;
+
+  /**
+   * Middle name of the person.
+   *
+   * @var string
+   */
+  protected string $middleName;
+
+  /**
+   * Last name of the person.
+   *
+   * @var string
+   */
+  protected string $lastName;
 
   /**
    * Street of the person.
@@ -251,6 +275,66 @@ class CprLookupResult {
    */
   public function setName(string $name): void {
     $this->name = $name;
+  }
+
+  /**
+   * Get first name.
+   *
+   * @return string
+   *   The first name.
+   */
+  public function getFirstName(): string {
+    return $this->firstName;
+  }
+
+  /**
+   * Set first name.
+   *
+   * @param string $firstName
+   *   The first name.
+   */
+  public function setFirstName(string $firstName): void {
+    $this->firstName = $firstName;
+  }
+
+  /**
+   * Get middle name.
+   *
+   * @return string
+   *   The middle name.
+   */
+  public function getMiddleName(): string {
+    return $this->middleName;
+  }
+
+  /**
+   * Set middle name.
+   *
+   * @param string $middleName
+   *   The middle name.
+   */
+  public function setMiddleName(string $middleName): void {
+    $this->middleName = $middleName;
+  }
+
+  /**
+   * Get last name.
+   *
+   * @return string
+   *   The last name.
+   */
+  public function getLastName(): string {
+    return $this->lastName;
+  }
+
+  /**
+   * Set last name.
+   *
+   * @param string $lastName
+   *   The last name.
+   */
+  public function setLastName(string $lastName): void {
+    $this->lastName = $lastName;
   }
 
   /**

--- a/src/Plugin/os2web/DataLookup/ServiceplatformenCPRExtended.php
+++ b/src/Plugin/os2web/DataLookup/ServiceplatformenCPRExtended.php
@@ -154,6 +154,9 @@ class ServiceplatformenCPRExtended extends ServiceplatformenBase implements Data
 
       if ($persondata->navn) {
         $cprResult->setName($persondata->navn->personadresseringsnavn ?? '');
+        $cprResult->setFirstName($persondata->navn->fornavn ?? '');
+        $cprResult->setMiddleName($persondata->navn->mellemnavn ?? '');
+        $cprResult->setLastName($persondata->navn->efternavn ?? '');
       }
 
       if (isset($persondata->foedselsdato)) {


### PR DESCRIPTION
#### Link to ticket

Closes OS2Forms/os2forms#329

#### Description

CPR lookup now also fetches first, middle and last name alongside full name.

> [!NOTE]
> We only update `Serviceplatformen CPR - extended (SF1520)`  as `Serviceplatformen CPR (SF6008)` is obsolete.
